### PR TITLE
Specufex - add badge

### DIFF
--- a/list.yml
+++ b/list.yml
@@ -6,3 +6,5 @@ SCOPED:
   status: containerized
 - name: Pyatoa
   status: containerized
+- name: Specufex
+  status: containerized


### PR DESCRIPTION
This commit will add specufex to the `list.yml` file to enable the SCOPED:containerized badge.